### PR TITLE
ci: flutter.yml timeout from 4 to 6 minutes

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   Setup-Flutter:
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: 6
     steps:
     - uses: actions/checkout@v2
     - uses: subosito/flutter-action@v1.5.3


### PR DESCRIPTION

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->
Last CI on beta was canceled due to 4 minutes timeout. I added 2 more minutes to it to make sure that it will always run in time.
