### PR TITLE
fix: MenuItem icon spacing

### DIFF
--- a/lib/component/lenra_menu.dart
+++ b/lib/component/lenra_menu.dart
@@ -70,7 +70,7 @@ class LenraMenuItem extends StatelessWidget {
         vertical: theme.baseSize / 2,
       ),
       child: LenraFlex(
-        spacing: 1,
+        spacing: 8,
         crossAxisAlignment: CrossAxisAlignment.center,
         fillParent: true,
         children: [


### PR DESCRIPTION

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I included unit tests that cover my changes
- [x] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->
After removing the `bsaeSize` factor for spacings, we forgot to change the menuItem icon spacing from 1 to 8.

