### PR TITLE
fix: Material update

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: subosito/flutter-action@v1.5.3
       with:
-        flutter-version: '3.0.x'
+        flutter-version: '3.10.x'
 
     - name: Restore packages
       run: flutter pub get

--- a/.github/workflows/generate_and_deploy_doc.yml
+++ b/.github/workflows/generate_and_deploy_doc.yml
@@ -5,7 +5,7 @@ on:
       - beta
 
 env:
-  flutter_version: "3.0.x"
+  flutter_version: "3.10.x"
 
 permissions:
   contents: write

--- a/examples/flutter_playground/lib/pages/my_lenra_menu.dart
+++ b/examples/flutter_playground/lib/pages/my_lenra_menu.dart
@@ -54,16 +54,12 @@ class _MyLenraMenuState extends State<MyLenraMenu> {
               LenraMenuItem(
                 text: "Coffee",
                 isSelected: selectedItems[0],
-                onPressed: () => {
-                  setState(() => {selectedItems[0] = !selectedItems[0]})
-                },
+                onPressed: () => {setState(() => selectedItems[0] = !selectedItems[0])},
               ),
               LenraMenuItem(
                 text: "Water",
                 isSelected: selectedItems[1],
-                onPressed: () => {
-                  setState(() => {selectedItems[1] = !selectedItems[1]})
-                },
+                onPressed: () => {setState(() => selectedItems[1] = !selectedItems[1])},
               ),
             ],
           ),

--- a/lib/component/lenra_dropdown_button.dart
+++ b/lib/component/lenra_dropdown_button.dart
@@ -96,7 +96,7 @@ class _LenraDropdownButtonState extends State<LenraDropdownButton> {
     } else {
       _overlayEntry ??= _createOverlayEntry();
 
-      Overlay.of(context)!.insert(_overlayEntry!);
+      Overlay.of(context).insert(_overlayEntry!);
       showOverlay = !showOverlay;
     }
   }

--- a/lib/component/lenra_table_row.dart
+++ b/lib/component/lenra_table_row.dart
@@ -15,10 +15,10 @@ class LenraTableRow extends TableRow {
     required EdgeInsetsGeometry padding,
     required LenraTableThemeData theme,
   }) {
-    List<Widget> res = List.from(children!);
+    List<Widget> res = List.from(children);
 
     // Wrap in LenraTableCell
-    for (var i = 0; i < children!.length; i++) {
+    for (var i = 0; i < children.length; i++) {
       res[i] = LenraTableCell(
         child: Padding(
           padding: padding,

--- a/lib/layout/lenra_overlay_entry.dart
+++ b/lib/layout/lenra_overlay_entry.dart
@@ -52,7 +52,7 @@ class _LenraOverlayEntryState extends State<LenraOverlayEntry> {
   void showOverlay() {
     overlayEntry = _createOverlayEntry();
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      Overlay.of(context)!.insert(overlayEntry);
+      Overlay.of(context).insert(overlayEntry);
     });
   }
 

--- a/lib/theme/lenra_button_theme_data.dart
+++ b/lib/theme/lenra_button_theme_data.dart
@@ -157,8 +157,9 @@ class LenraButtonThemeData {
       foregroundColor: foregroundColor.resolve(type),
       backgroundColor: backgroundColor.resolve(type),
       side: side.resolve(type),
-      padding: MaterialStateProperty.all(EdgeInsets.zero),
-      minimumSize: MaterialStateProperty.all(Size.zero),
+      shape: const MaterialStatePropertyAll(RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4)))),
+      padding: const MaterialStatePropertyAll(EdgeInsets.zero),
+      minimumSize: const MaterialStatePropertyAll(Size.zero),
       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
     );
   }

--- a/test/component/lenra_table_row_test.dart
+++ b/test/component/lenra_table_row_test.dart
@@ -19,7 +19,7 @@ void main() {
               padding: const EdgeInsets.symmetric(vertical: 1 * 8.0, horizontal: 2 * 8.0),
               theme: LenraTableThemeData(lenraThemeData: LenraThemeData()),
             )
-            .children!
+            .children
             .first is LenraTableCell,
         true);
   });


### PR DESCRIPTION
## About this PR
This PR is about the Flutter Material update from 2 to 3. It changed some widgets style so we need to change that so that they correspond to the design on Figma.
In this PR I mainly fixed the button which had a too much rounded border following the update of Material. I also found that the Switch widget changed a lot but it is closer to our design so this is good for us. We might need to adapt the thumb size to match our design. I opened another issue for the Switch.

## Technical highlight/advice
<!-- 
    This part is for technical stuff.
    - Tell us what did you change to implement the feature or fix the bug.
    - Don't detail it too much if it's simple stuff.
    - Add more information if you made significant changes that can affect others.

    For example : 
    To create the new API, I've created a new `CGUController` and a `CGU` Context.
    2 new routes : 
     - GET /api/cgu
     - POST /api/cgu/accept
    I've created a new table in the database with a migration.
    The CGU is linked to the user (Many to Many).
    I've added the rule to deny anyone that did not accept the CGU.
-->

## How to test my changes
<!-- 
  - How to start the project. Any other dependancies to update ? Any database migration ?
  - Step-by-step guide to reproduce the bug or test the new feature.

  Try to be rather explicit but keep it as simple as possible.

  Example : 
  - On server : 
    - `git checkout implement-cgu-validation`
    - `mix ecto.reset`
    - `mix ecto.migrate`
    - `mix phx.server`
  Use the thunder client in vscode : 
  - Register/Login (get the token)
  - Try to access this api without validating CGU : GET /api/apps. It should fail.
  - Validate the CGU ising the API POST /api/cgu/accept
  - Access the API agail, now it should work.
-->


## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


